### PR TITLE
stop relying on . in @INC

### DIFF
--- a/examples/demo.t
+++ b/examples/demo.t
@@ -30,3 +30,4 @@ cmp_deeply(
 );
 
 done_testing if not $INC{'Test/Tester.pm'};
+1;

--- a/t/02-verify-example.t
+++ b/t/02-verify-example.t
@@ -8,7 +8,7 @@ use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 check_tests(
     sub {
         local $Test::Builder::Level = $Test::Builder::Level + 1;
-        do 'examples/demo.t'
+        do './examples/demo.t' or die $@;
     },
     [
         {


### PR DESCRIPTION
Also propagate errors from loading the example test.
